### PR TITLE
fix: APP-113 Only accept number for size to prevent crashes on Android devices

### DIFF
--- a/src/lib/index.tsx
+++ b/src/lib/index.tsx
@@ -13,7 +13,7 @@ export type PaintFunction = (color: string) => React.ReactNode | null;
 
 export interface IconProps {
   color?: string;
-  size?: string | number;
+  size?: number;
   weight?: IconWeight;
   style?: StyleProp<ViewStyle>;
   mirrored?: boolean;


### PR DESCRIPTION
The lib exposes components that crash the app when passing **allowed** props.
For instance `<Spinner size='large' />` is allowed by the typings, but will crash on Android because the underlying native component receives a string when it was expecting a number.